### PR TITLE
fixed deletion bug & changing chats mid-response bug

### DIFF
--- a/client/src/components/organisms/RightSection/RightSection.js
+++ b/client/src/components/organisms/RightSection/RightSection.js
@@ -5,7 +5,7 @@ import ChatPanel from '../ChatPanel/ChatPanel';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   createUserMessageInActiveChat,
-  getGptResponseInActiveChat,
+  getGptResponseForUserMessage,
   setCurrentUserInput,
 } from '../../../redux/messagesSlice';
 import {
@@ -15,7 +15,7 @@ import {
 import { ArrowForwardIcon } from '@chakra-ui/icons';
 import { createChatWithSelectedDropdownCourse } from '../../../redux/chatsSlice';
 
-const Message = ({value}) => (
+const Message = ({ value }) => (
   <div className={styles.message}>
     <p>{value}</p>
   </div>
@@ -49,7 +49,11 @@ const InputArea = ({
         <ArrowForwardIcon />
       </button>
     </div>
-    <Message value={"CourseGPT may produce inaccurate information about instructors or course content. [CourseGPT 2023 Version]"}/>
+    <Message
+      value={
+        'CourseGPT may produce inaccurate information about instructors or course content. [CourseGPT 2023 Version]'
+      }
+    />
   </div>
 );
 
@@ -83,7 +87,7 @@ const RightSection = () => {
     dispatch(setActivePanelChat());
     dispatch(createUserMessageInActiveChat(currentUserInput)).then(
       newMessagePayload => {
-        dispatch(getGptResponseInActiveChat(newMessagePayload.payload));
+        dispatch(getGptResponseForUserMessage(newMessagePayload.payload));
       }
     );
   };

--- a/client/src/components/organisms/RightSection/RightSection.module.css
+++ b/client/src/components/organisms/RightSection/RightSection.module.css
@@ -47,7 +47,7 @@
   font-size: 12px;
   margin-top: 10px;
   text-align: center;
-  color: rgb(197,197,210);
+  color: rgb(197, 197, 210);
 }
 
 .sendBtn {


### PR DESCRIPTION
Fixed two issues here:
1) Previously, if a user cleared chats with a chat open, or deleted the chat that they had open, they could still send a message into the open chat. Now, they can not.
2) Previously, if a user switched chats mid-gpt response, the gpt-response would show in the new chat they selected (rather than the one they sent their message in). Now, the responses only occur in the correct chat.